### PR TITLE
[vbump] Tag before push

### DIFF
--- a/scripts/vbump
+++ b/scripts/vbump
@@ -107,7 +107,6 @@ checkgit
 if [ -z $TAG_ONLY ]; then
   run git add .
   run git commit -m "$COMMIT_MSG"
-  run git push origin master
 fi
 
 #
@@ -115,6 +114,13 @@ fi
 #
 run git tag -a "v$VERSION" -m "Version $VERSION"
 run git push --tags
+
+#
+# Push to `master` only if `-t` is not set
+#
+if [ -z $TAG_ONLY ]; then
+  run git push origin master
+fi
 
 # Check for a package.json
 if [ -z $NO_NPM ]; then

--- a/scripts/vbump
+++ b/scripts/vbump
@@ -112,7 +112,7 @@ fi
 #
 # Always tag since we are version bumping.
 #
-run git tag -a "v$VERSION" -m "Version $VERSION"
+run git tag -a "$VERSION" -m "Version $VERSION"
 run git push --tags
 
 #


### PR DESCRIPTION
### Was previously
1. `git commit` locally
2. `git push` to `master`
3. `git tag` and push

### Is currently
1. `git commit` locally
2. `git tag` and push
3. `git push` to `master`
