### PR TITLE
Release: 2026.06.01

### DIFF
--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -171,6 +171,8 @@ esac
 
 eval "$(mise activate zsh)"
 
+if command -v wt >/dev/null 2>&1; then eval "$(command wt config shell init zsh)"; fi
+
 # Starship
 export STARSHIP_CONFIG="$HOME/Library/Application Support/starship/starship.toml"
 

--- a/install/holepunch
+++ b/install/holepunch
@@ -1,0 +1,18 @@
+#!/bin/zsh
+
+# Holepunch / Pear toolchain.
+#
+# Must be npm, NOT pnpm: gip-transport ships a bin named `git-remote-git+pear`
+# (git's remote helper for `git+pear://` URLs) and pnpm silently drops any bin
+# whose name contains `+`, so the helper never lands on PATH and clones fail
+# with: git: 'remote-git+pear' is not a git command.
+# npm links it correctly. Neither package has install scripts, so they're fine
+# under npm_config_ignore_scripts=true (see .security). bare-runtime ships the
+# prebuilt `bare` binary inside the tarball.
+
+set -x;
+
+npm i -g bare-runtime  # `bare` runtime — gip's git-remote helper runs on it
+npm i -g gip-transport # git+pear:// transport: git-remote-git+pear, git-pear, gip
+
+set +x;

--- a/scripts/hostdiff
+++ b/scripts/hostdiff
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# hostdiff - Diff this dotfiles repo against the current machine
+# Usage: hostdiff [files|symlinks|brew|mise|all]
+set -euo pipefail
+
+DOTFILES="$(cd "$(dirname "$0")/.." && pwd)"
+
+# ── Output helpers ────────────────────────────────────────────────────────────
+_ok()      { printf "  \033[32m[ok]\033[0m      %s\n" "$*"; }
+_diff()    { printf "  \033[33m[diff]\033[0m    %s\n" "$*"; }
+_missing() { printf "  \033[31m[missing]\033[0m %s\n" "$*"; }
+_skip()    { printf "  \033[2m[skip]\033[0m    %s\n" "$*"; }
+_section() { printf "\n\033[1m── %s\033[0m\n" "$*"; }
+
+# Lines allowed to exist in the live file but not in the dotfiles source.
+# Tools that append to shell files post-install produce these.
+_dynamic_line() {
+  local line="$1"
+  [[ "$line" =~ 'wt config shell init' ]] && return 0
+  [[ "$line" =~ 'GITHUB_TOKEN=' ]] && return 0
+  [[ "$line" =~ '# Added by ' ]] && return 0
+  return 1
+}
+
+# Normalize a file for comparison: strip known dynamic lines and trailing whitespace
+_normalize() {
+  local file="$1"
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    _dynamic_line "$line" && continue
+    printf '%s\n' "${line%"${line##*[![:space:]]}"}"
+  done < "$file"
+}
+
+# ── File lens ─────────────────────────────────────────────────────────────────
+check_files() {
+  _section "dotfiles"
+  local any_diff=0
+
+  for src in "$DOTFILES/dotfiles"/.*; do
+    [[ -f "$src" ]] || continue
+    local file dst
+    file="$(basename "$src")"
+    dst="$HOME/$file"
+
+    if [[ ! -e "$dst" ]]; then
+      _missing "$file  →  run: zsh install/setup.sh"
+      any_diff=1
+      continue
+    fi
+
+    local src_norm dst_norm diff_out
+    src_norm="$(_normalize "$src")"
+    dst_norm="$(_normalize "$dst")"
+
+    if [[ "$src_norm" == "$dst_norm" ]]; then
+      _ok "$file"
+    else
+      _diff "$file"
+      diff_out="$(diff <(echo "$src_norm") <(echo "$dst_norm") || true)"
+      echo "$diff_out" | grep '^[<>]' | head -12 | sed 's/^< /    \033[31m- /; s/^> /    \033[32m+ /' | while IFS= read -r l; do printf "%b\033[0m\n" "$l"; done
+      any_diff=1
+    fi
+  done
+
+  return $any_diff
+}
+
+# ── Symlink lens ──────────────────────────────────────────────────────────────
+check_symlinks() {
+  _section "symlinks"
+
+  _check_link() {
+    local _lname="$1" _src="$2" _dst="$3" _cmd="${4:-install/$1}"
+    if [[ ! -e "$_dst" && ! -L "$_dst" ]]; then
+      _missing "$_lname  →  run: zsh $_cmd"
+    elif [[ ! -L "$_dst" ]]; then
+      _diff "$_lname  (real file/dir, not a symlink — run: zsh $_cmd)"
+    elif [[ "$(readlink "$_dst")" != "$_src" ]]; then
+      _diff "$_lname  (→ $(readlink "$_dst"), expected $_src)"
+    else
+      _ok "$_lname"
+    fi
+  }
+
+  _check_link "ghostty"   "$DOTFILES/settings/ghostty"             "$HOME/Library/Application Support/com.mitchellh.ghostty"
+  _check_link "mise"      "$DOTFILES/settings/mise"                "$HOME/Library/Application Support/mise"
+  _check_link "starship"  "$DOTFILES/settings/starship"            "$HOME/Library/Application Support/starship"
+  _check_link "worktrunk" "$DOTFILES/settings/worktrunk/config.toml" "$HOME/.config/worktrunk/config.toml" "install/worktrunk"
+}
+
+# ── Brew lens ─────────────────────────────────────────────────────────────────
+check_brew() {
+  _section "brew"
+
+  if ! command -v brew >/dev/null 2>&1; then
+    _skip "brew not installed"
+    return
+  fi
+
+  local brewfile_dir="$DOTFILES/install/brew.d"
+  local any_diff=0
+
+  for brewfile in "$brewfile_dir"/Brewfile.*; do
+    local bfname out
+    bfname="$(basename "$brewfile")"
+    if out="$(brew bundle check --verbose --file="$brewfile" 2>&1)"; then
+      _ok "$bfname"
+    else
+      _diff "$bfname"
+      echo "$out" | grep -v '^Using\|^Tapping\|^Verifying\|^$\|dependencies are' \
+        | sed 's/^/    /' || true
+      any_diff=1
+    fi
+  done
+
+  return $any_diff
+}
+
+# ── Mise lens ─────────────────────────────────────────────────────────────────
+check_mise() {
+  _section "mise"
+
+  if ! command -v mise >/dev/null 2>&1; then
+    _skip "mise not installed"
+    return
+  fi
+
+  local missing_tools
+  missing_tools="$(XDG_CONFIG_HOME="$HOME/Library/Application Support" \
+    MISE_DATA_DIR="$HOME/.local/share/mise" \
+    mise ls --missing 2>/dev/null | grep -v '^$' || true)"
+
+  if [[ -z "$missing_tools" ]]; then
+    _ok "all tools installed"
+  else
+    while IFS= read -r line; do
+      [[ -z "$line" ]] && continue
+      _missing "$line  →  run: mise install"
+    done <<< "$missing_tools"
+  fi
+}
+
+# ── Dispatch ──────────────────────────────────────────────────────────────────
+MODE="${1:-all}"
+EXIT=0
+
+case "$MODE" in
+  files)    check_files    || EXIT=1 ;;
+  symlinks) check_symlinks || EXIT=1 ;;
+  brew)     check_brew     || EXIT=1 ;;
+  mise)     check_mise     || EXIT=1 ;;
+  all)
+    check_files    || EXIT=1
+    check_symlinks || EXIT=1
+    check_brew     || EXIT=1
+    check_mise     || EXIT=1
+    ;;
+  *)
+    echo "Usage: hostdiff [files|symlinks|brew|mise|all]" >&2
+    exit 1
+    ;;
+esac
+
+echo ""
+exit $EXIT

--- a/scripts/hostdiff
+++ b/scripts/hostdiff
@@ -5,24 +5,34 @@ set -euo pipefail
 
 DOTFILES="$(cd "$(dirname "$0")/.." && pwd)"
 
-# ── Output helpers ────────────────────────────────────────────────────────────
-_ok()      { printf "  \033[32m[ok]\033[0m      %s\n" "$*"; }
-_diff()    { printf "  \033[33m[diff]\033[0m    %s\n" "$*"; }
-_missing() { printf "  \033[31m[missing]\033[0m %s\n" "$*"; }
-_skip()    { printf "  \033[2m[skip]\033[0m    %s\n" "$*"; }
+# ── Visual language ───────────────────────────────────────────────────────────
+# ✓  green  — matches
+# ~  yellow — differs
+# ✗  red    — missing entirely
+# -  dim    — skipped (tool not available)
+#
+# Symbol grammar:
+#   →   symlink currently points to (only here)
+#   $   shell command to run to fix
+#   -/+ removed/added lines in a diff
+
+_ok()      { printf "  \033[2m✓  %s\033[0m\n" "$*"; }
+_diff()    { printf "  \033[33m~  %s\033[0m\n" "$*"; }
+_missing() { printf "  \033[31m✗  %s\033[0m\n" "$*"; }
+_skip()    { printf "  \033[2m-  %s\033[0m\n" "$*"; }
+_fix()     { printf "     \033[2m\$  %s\033[0m\n" "$*"; }
 _section() { printf "\n\033[1m── %s\033[0m\n" "$*"; }
 
-# Lines allowed to exist in the live file but not in the dotfiles source.
-# Tools that append to shell files post-install produce these.
+# ── Normalization ─────────────────────────────────────────────────────────────
+# Lines allowed to differ: tools that append to shell files post-install
 _dynamic_line() {
   local line="$1"
   [[ "$line" =~ 'wt config shell init' ]] && return 0
-  [[ "$line" =~ 'GITHUB_TOKEN=' ]] && return 0
-  [[ "$line" =~ '# Added by ' ]] && return 0
+  [[ "$line" =~ 'GITHUB_TOKEN=' ]]        && return 0
+  [[ "$line" =~ '# Added by ' ]]          && return 0
   return 1
 }
 
-# Normalize a file for comparison: strip known dynamic lines and trailing whitespace
 _normalize() {
   local file="$1"
   while IFS= read -r line || [[ -n "$line" ]]; do
@@ -43,12 +53,13 @@ check_files() {
     dst="$HOME/$file"
 
     if [[ ! -e "$dst" ]]; then
-      _missing "$file  →  run: zsh install/setup.sh"
+      _missing "$file"
+      _fix "zsh install/setup.sh"
       any_diff=1
       continue
     fi
 
-    local src_norm dst_norm diff_out
+    local src_norm dst_norm
     src_norm="$(_normalize "$src")"
     dst_norm="$(_normalize "$dst")"
 
@@ -56,8 +67,11 @@ check_files() {
       _ok "$file"
     else
       _diff "$file"
-      diff_out="$(diff <(echo "$src_norm") <(echo "$dst_norm") || true)"
-      echo "$diff_out" | grep '^[<>]' | head -12 | sed 's/^< /    \033[31m- /; s/^> /    \033[32m+ /' | while IFS= read -r l; do printf "%b\033[0m\n" "$l"; done
+      diff <(echo "$src_norm") <(echo "$dst_norm") \
+        | grep '^[<>]' | head -12 \
+        | sed 's|^< |     \x1b[31m- |; s|^> |     \x1b[32m+ |' \
+        | while IFS= read -r l; do printf "%b\033[0m\n" "$l"; done
+      _fix "zsh install/setup.sh"
       any_diff=1
     fi
   done
@@ -72,19 +86,24 @@ check_symlinks() {
   _check_link() {
     local _lname="$1" _src="$2" _dst="$3" _cmd="${4:-install/$1}"
     if [[ ! -e "$_dst" && ! -L "$_dst" ]]; then
-      _missing "$_lname  →  run: zsh $_cmd"
+      _missing "$_lname"
+      _fix "zsh $_cmd"
     elif [[ ! -L "$_dst" ]]; then
-      _diff "$_lname  (real file/dir, not a symlink — run: zsh $_cmd)"
+      _diff "$_lname  (not a symlink)"
+      _fix "zsh $_cmd"
     elif [[ "$(readlink "$_dst")" != "$_src" ]]; then
-      _diff "$_lname  (→ $(readlink "$_dst"), expected $_src)"
+      _diff "$_lname"
+      printf "     \033[2mis:   $(readlink "$_dst")\033[0m\n"
+      printf "     \033[2mwant: $_src\033[0m\n"
+      _fix "zsh $_cmd"
     else
       _ok "$_lname"
     fi
   }
 
-  _check_link "ghostty"   "$DOTFILES/settings/ghostty"             "$HOME/Library/Application Support/com.mitchellh.ghostty"
-  _check_link "mise"      "$DOTFILES/settings/mise"                "$HOME/Library/Application Support/mise"
-  _check_link "starship"  "$DOTFILES/settings/starship"            "$HOME/Library/Application Support/starship"
+  _check_link "ghostty"   "$DOTFILES/settings/ghostty"              "$HOME/Library/Application Support/com.mitchellh.ghostty"
+  _check_link "mise"      "$DOTFILES/settings/mise"                 "$HOME/Library/Application Support/mise"
+  _check_link "starship"  "$DOTFILES/settings/starship"             "$HOME/Library/Application Support/starship"
   _check_link "worktrunk" "$DOTFILES/settings/worktrunk/config.toml" "$HOME/.config/worktrunk/config.toml" "install/worktrunk"
 }
 
@@ -107,8 +126,12 @@ check_brew() {
       _ok "$bfname"
     else
       _diff "$bfname"
-      echo "$out" | grep -v '^Using\|^Tapping\|^Verifying\|^$\|dependencies are' \
-        | sed 's/^/    /' || true
+      echo "$out" \
+        | grep -v '^Using\|^Tapping\|^Verifying\|^$\|dependencies are\|Satisfy missing' \
+        | sed 's/^[[:space:]]*/     /' \
+        | sed 's/^     → /     \x1b[31m✗  /' \
+        | while IFS= read -r l; do printf "%b\033[0m\n" "$l"; done
+      _fix "brew bundle install --file=$brewfile"
       any_diff=1
     fi
   done
@@ -135,8 +158,9 @@ check_mise() {
   else
     while IFS= read -r line; do
       [[ -z "$line" ]] && continue
-      _missing "$line  →  run: mise install"
+      _missing "$line"
     done <<< "$missing_tools"
+    _fix "mise install"
   fi
 }
 

--- a/scripts/wtr
+++ b/scripts/wtr
@@ -1,12 +1,14 @@
 #!/bin/zsh
 
 # wtr - Navigate between git worktrees and main repo
-# Usage: wtr [worktree-name | 1 | list]
+# Usage:
 #   wtr           - go to main repo
 #   wtr 1         - go to main repo (git gtr compat)
-#   wtr <name>    - go to worktree by folder name
+#   wtr <name>    - go to named worktree
 #   wtr list      - list available worktrees
-# Must be sourced, not executed directly
+#
+# Prefers worktrunk (wt) when available; falls back to path heuristics
+# for git-worktree-runner compat. Must be sourced, not executed directly.
 
 if [ -z "$GIT_ROOT" ]; then
   GIT_ROOT="Git"
@@ -14,69 +16,69 @@ fi
 
 GIT_DIR="$HOME/$GIT_ROOT"
 
-# Get path relative to GIT_DIR
 REL_PATH="${PWD#$GIT_DIR/}"
-
-# Split the relative path into components
 IFS='/' read -A PARTS <<< "$REL_PATH"
 GIT_ORG="${PARTS[1]}"
 GIT_REPO="${PARTS[2]}"
 
-# Determine if we're in a worktree or main repo
 if [[ "$GIT_REPO" == *-worktrees ]]; then
-  # We're in a worktree directory
   MAIN_REPO="${GIT_REPO%-worktrees}"
   WORKTREES_DIR="$GIT_DIR/$GIT_ORG/$GIT_REPO"
 else
-  # We're in the main repo or somewhere else
   MAIN_REPO="$GIT_REPO"
   WORKTREES_DIR="$GIT_DIR/$GIT_ORG/${MAIN_REPO}-worktrees"
 fi
 
 MAIN_REPO_DIR="$GIT_DIR/$GIT_ORG/$MAIN_REPO"
 
-# Handle arguments
-case "$1" in
+_wt_available() { command -v wt >/dev/null 2>&1; }
+
+case "${1:-}" in
   ""|1)
-    # Go to main repo
     if [ ! -d "$MAIN_REPO_DIR" ]; then
       echo "[x] Main repo not found: $MAIN_REPO_DIR"
       return 1 2>/dev/null || exit 1
     fi
     cd "$MAIN_REPO_DIR"
-    echo "Main repo: $MAIN_REPO_DIR"
+    echo "↩ $MAIN_REPO_DIR"
     ;;
   list)
-    # List available worktrees
-    echo "Main repo:"
-    echo "  1  $MAIN_REPO_DIR"
-    echo ""
-    if [ -d "$WORKTREES_DIR" ]; then
-      echo "Worktrees:"
-      for wt in "$WORKTREES_DIR"/*(N/); do
-        echo "  $(basename "$wt")  $wt"
-      done
+    if _wt_available; then
+      wt list
     else
-      echo "No worktrees directory found"
+      echo "Main repo:"
+      echo "  1  $MAIN_REPO_DIR"
+      echo ""
+      if [ -d "$WORKTREES_DIR" ]; then
+        echo "Worktrees:"
+        for wt_dir in "$WORKTREES_DIR"/*(N/); do
+          echo "  $(basename "$wt_dir")  $wt_dir"
+        done
+      else
+        echo "No worktrees directory found"
+      fi
     fi
     ;;
   *)
-    # Go to specific worktree
-    WORKTREE_PATH="$WORKTREES_DIR/$1"
-    if [ ! -d "$WORKTREE_PATH" ]; then
-      echo "[x] Worktree not found: $WORKTREE_PATH"
-      echo ""
-      echo "Available worktrees:"
-      if [ -d "$WORKTREES_DIR" ]; then
-        for wt in "$WORKTREES_DIR"/*(N/); do
-          echo "  $(basename "$wt")"
-        done
-      else
-        echo "  (none)"
+    if _wt_available; then
+      wt switch "$1"
+    else
+      WORKTREE_PATH="$WORKTREES_DIR/$1"
+      if [ ! -d "$WORKTREE_PATH" ]; then
+        echo "[x] Worktree not found: $WORKTREE_PATH"
+        echo ""
+        echo "Available worktrees:"
+        if [ -d "$WORKTREES_DIR" ]; then
+          for wt_dir in "$WORKTREES_DIR"/*(N/); do
+            echo "  $(basename "$wt_dir")"
+          done
+        else
+          echo "  (none)"
+        fi
+        return 1 2>/dev/null || exit 1
       fi
-      return 1 2>/dev/null || exit 1
+      cd "$WORKTREE_PATH"
+      echo "↳ $WORKTREE_PATH"
     fi
-    cd "$WORKTREE_PATH"
-    echo "Worktree: $WORKTREE_PATH"
     ;;
 esac

--- a/settings/worktrunk/templates/short.toml
+++ b/settings/worktrunk/templates/short.toml
@@ -9,11 +9,10 @@ No colon after the closing parenthesis. Subject line soft limit: 50 chars.
 
 Valid types:
   fix, feat, refactor, chore, doc, build, dist, test, infra, data, nit,
-  close, spv, skunkworks, agents
+  spv, skunkworks, agents
 
-Common topics (adjust per repo):
-  argo, ci, deps, docker, duckdb, infrastructure, integration,
-  lockfiles, monorepo, workflow
+Common topics (investigate commits per repo to build this list):
+  ci, deps, docker, <pkg>, infra, integration, monorepo, workflow
 
 Rules:
 - One type and one topic per commit


### PR DESCRIPTION
## Release: 2026.06.01

**Scripts**
- `hostdiff` — diff this repo against the live machine across four lenses: Exits 1 on any drift; 
every line prints the `$` fix command. (✓ match · ~ differs · ✗ missing · - skipped)
   - files (with a dynamic-line allowlist for tool-appended shell lines)
   - symlinks (exists / is-link / points-right)
   - brew (`bundle check` per `Brewfile.<set>`),
   - mise (`ls --missing`). 
- `wtr` — prefer `wt switch`/`wt list` when worktrunk is available, falling back
  to path heuristics for git-worktree-runner compat; returns the main repo with
  `↩` and worktrees with `↳`

**Worktrees**
- `wt` shell integration added to `.zshrc` (`eval "$(wt config shell init zsh)"`,
  guarded on `command -v wt`) so `wt switch`/`start` auto-`cd` into the target
  worktree
- worktrunk commit-message template renamed to `short.toml` to align with
  current naming conventions; type/topic lists trimmed to the generally-useful
  set

**Install** 
- `install/holepunch` deploys the Holepunch/Pear toolchain (`bare-runtime`, `gip-transport`). 
   - Deliberately uses `npm -g`, **not** pnpm: `gip-transport` ships a `git-remote-git+pear` 
     helper and pnpm silently drops any bin whose name contains `+`, breaking `git+pear://` 
     clones. Neither package has install scripts, so both are safe under
     `npm_config_ignore_scripts=true` (see `.security`)
