### PR TITLE
workstation: nix seed — standalone home-manager, first migration slice

### DIFF
--- a/install/nix
+++ b/install/nix
@@ -1,0 +1,21 @@
+#!/usr/bin/env zsh
+set -e
+
+DOTFILES="$(cd "${0:A:h}/.." && pwd)"
+WORKSTATION="$DOTFILES/workstation"
+
+if ! command -v nix >/dev/null 2>&1; then
+  echo "nix is not installed. Bootstrap first:"
+  echo "  curl -fsSL https://install.determinate.systems/nix | sh -s -- install"
+  echo "then see $WORKSTATION/README.md"
+  exit 1
+fi
+
+if command -v home-manager >/dev/null 2>&1; then
+  home-manager switch --flake "$WORKSTATION#cjr"
+else
+  # First run: bootstrap home-manager from its flake
+  nix run github:nix-community/home-manager -- switch --flake "$WORKSTATION#cjr"
+fi
+
+echo "Switched. Rollback: home-manager generations"

--- a/workstation/README.md
+++ b/workstation/README.md
@@ -1,0 +1,38 @@
+# workstation — the nix seed
+
+Standalone [home-manager](https://github.com/nix-community/home-manager)
+managing a growing slice of `$HOME`. Deliberately the *simple system that
+works* (Gall's Law): no nix-darwin, no hosts, no profiles, no sudo — those
+live in robbinshinds.family/workstation and this seed forward-ports there
+when it has earned it. `install/setup.sh` keeps owning every category not
+yet listed in `home.nix`.
+
+## Bootstrap (once)
+
+```sh
+# 1. Install nix
+curl -fsSL https://install.determinate.systems/nix | sh -s -- install
+
+# 2. First switch (also generates flake.lock — commit it!)
+cd ~/Git/indexzero/dotfiles/workstation
+nix run github:nix-community/home-manager -- switch --flake .#cjr
+git add flake.lock && git commit -m "chore(workstation): pin flake inputs"
+```
+
+## Every time after
+
+```sh
+install/nix        # or: home-manager switch --flake ~/Git/indexzero/dotfiles/workstation#cjr
+```
+
+## Migration ledger
+
+| Category | Owner |
+|---|---|
+| CLI tools (`brew.d/Brewfile.cli`) | **home.nix** (exa→eza; ccat/nono/googleworkspace-cli/fonts stay brew) |
+| try (`tryme` + shell function) | **home.nix** (`programs.try`, via the try.rs flake) |
+| starship / atuin binaries | **home.nix** (configs still `settings/` — next slice) |
+| everything else | `install/setup.sh`, as always |
+
+Rollback: `home-manager generations` lists them; activate any previous one
+directly. Your `.backup/` dir remains untouched by all of this.

--- a/workstation/flake.nix
+++ b/workstation/flake.nix
@@ -1,0 +1,37 @@
+{
+  # The simple system that works (Gall's Law seed).
+  #
+  # Standalone home-manager only: no nix-darwin, no hosts, no profiles, no
+  # sudo. It manages exactly the slice of $HOME declared in home.nix and
+  # nothing else; install/setup.sh keeps owning every unported category.
+  # When this has grown enough working parts, it forward-ports to
+  # robbinshinds.family/workstation (home.nix is content-identical to
+  # users/cjr/home.nix there, minus the profile import).
+  description = "Charlie's home configuration — dotfiles nix seed";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    # try-me-maybe: Rust port of tobi/try (ships a home-manager module).
+    # Requires indexzero/try.rs#5 (nix flake) merged to main.
+    try = {
+      url = "github:indexzero/try.rs";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { nixpkgs, home-manager, try, ... }: {
+    homeConfigurations."cjr" = home-manager.lib.homeManagerConfiguration {
+      pkgs = nixpkgs.legacyPackages.aarch64-darwin;
+      modules = [
+        try.homeModules.default
+        ./home.nix
+      ];
+    };
+  };
+}

--- a/workstation/home.nix
+++ b/workstation/home.nix
@@ -1,0 +1,53 @@
+# Charlie — home configuration (dotfiles nix seed)
+#
+# First slice ported from install/: the Brewfile.cli formula list (as nix
+# packages) plus try-me-maybe via its home-manager module. Tool configs
+# (starship.toml, atuin, git) are the NEXT slice — until then
+# install/setup.sh still owns them, and these programs pick up those
+# configs from their usual locations.
+#
+# Forward-port note: keep this file content-identical to
+# robbinshinds.family workstation/users/cjr/home.nix (minus its profile
+# import) so promotion is a copy, not a rewrite.
+{ config, pkgs, lib, ... }:
+
+{
+  home.username = "cjr";
+  home.homeDirectory = "/Users/cjr";
+  home.stateVersion = "24.05";
+
+  programs.try.enable = true;
+  # path defaults to ~/src/tries — set explicitly when you want elsewhere:
+  # programs.try.path = "~/src/tries";
+
+  # install/brew.d/Brewfile.cli, as nixpkgs packages.
+  # Substitutions from the Brewfile, recorded honestly:
+  #   exa  -> eza   (exa is unmaintained; eza is its continuation)
+  #   ccat -> left in brew.d (not in nixpkgs)
+  #   nono, googleworkspace-cli -> not in nixpkgs; stay brew/bespoke
+  #   font-meslo-lg-nerd-font (cask) -> stays in brew.d
+  home.packages = with pkgs; [
+    tree
+    bat
+    eza
+    fd
+    fzf
+    coreutils
+    duf
+    dust
+    xsv
+    jq
+    yq-go
+    jnv
+    tmux
+    gum
+    glow
+    ttyd
+  ];
+
+  # Enabled with their defaults; the starship.toml/atuin config port from
+  # settings/ is the next slice (home-manager will then own the files and
+  # install/starship + install/atuin retire).
+  programs.starship.enable = true;
+  programs.atuin.enable = true;
+}


### PR DESCRIPTION
The inverse of [robbinshinds.family#10](https://github.com/indexzero/robbinshinds.family/pull/10), per Gall's Law: that repo was the complex system built from scratch; the working simple system is this one, so the nix migration iterates here. That PR stays up as the eventual destination — `workstation/home.nix` is kept content-identical to its `users/cjr/home.nix` (minus the profile import) so forward-porting is a copy, not a rewrite.

## Smallest possible seed

Four files, no system management, no sudo, fully coexistent with `install/setup.sh`:

- **`workstation/flake.nix`** — standalone home-manager (`homeConfigurations.cjr`), inputs: nixpkgs, home-manager, and `try` (the try.rs flake, `nixpkgs.follows`)
- **`workstation/home.nix`** — the first slice: `Brewfile.cli` as `home.packages` (substitutions recorded: `exa`→`eza`; `ccat`/`nono`/`googleworkspace-cli`/fonts stay in brew.d), `programs.try.enable = true`, starship + atuin binaries
- **`workstation/README.md`** — bootstrap, the migration ledger (what home.nix owns vs what setup.sh still owns), rollback via generations
- **`install/nix`** — your install-script idiom: bootstraps home-manager on first run, plain `switch` thereafter

## What this deliberately is NOT

No nix-darwin, no hosts/profiles, no brew management, no macOS defaults — none of the machinery that stalled the family repo. Categories migrate one PR at a time, each retiring its `install/*` script when its *configs* (not just binaries) move over. starship/atuin `settings/` are the natural next slice.

## Bring-up

1. Merge [try.rs#5](https://github.com/indexzero/try.rs/pull/5)
2. `curl -fsSL https://install.determinate.systems/nix | sh -s -- install`
3. `install/nix` → commit the generated `flake.lock`
4. Smoke: new shell → `type try` → `try nix-seed-worked`

Not build-verified (no nix on this machine yet — that being the point); shapes mirror the eval-checked family-repo PR.